### PR TITLE
Fix some examples in the specification

### DIFF
--- a/specification/level-1-version-3/examples/lorenz-cellml/lorenz.xml
+++ b/specification/level-1-version-3/examples/lorenz-cellml/lorenz.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<sedML level="1" version="2" xmlns="http://sed-ml.org/sed-ml/level1/version2" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+<sedML level="1" version="3" xmlns="http://sed-ml.org/sed-ml/level1/version3" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
     <listOfSimulations>
         <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="10000" outputEndTime="50" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">

--- a/specification/level-1-version-3/examples/plotting-data-numl/plotting-data-numl.xml
+++ b/specification/level-1-version-3/examples/plotting-data-numl/plotting-data-numl.xml
@@ -3,8 +3,7 @@
     <listOfDataDescriptions>
         <dataDescription id="Data1" name="oscillator data" source="./oscli.numl" format="urn:sedml:format:numl">
             <dimensionDescription>
-                <compositeDescription indexType="double" id="time" name="time" xmlns="http://www.numl.org/numl/
-level1/version1">
+                <compositeDescription indexType="double" id="time" name="time" xmlns="http://www.numl.org/numl/level1/version1">
                     <compositeDescription indexType="string" id="SpeciesIds" name="SpeciesIds">
                         <atomicDescription valueType="double" name="Concentrations"/>
                     </compositeDescription>

--- a/specification/level-1-version-4/examples/ikappab/ikappab.xml
+++ b/specification/level-1-version-4/examples/ikappab/ikappab.xml
@@ -63,13 +63,13 @@
   <listOfOutputs>
     <plot2D id="plot1" name="BM140 Total_NFkBn">
       <listOfCurves>
-        <curve  id="c1" logX="false" logY="false" xDataReference="time" 
+        <curve  id="c1" xDataReference="time" 
         yDataReference="Total_NFkBn" />
-            <curve  id="c2" logX="false" logY="false" xDataReference="time"
+            <curve  id="c2" xDataReference="time"
         yDataReference="Total_IkBbeta" />
-        <curve  id="c3" logX="false" logY="false" xDataReference="time"
+        <curve  id="c3" xDataReference="time"
         yDataReference="Total_IkBeps" />
-        <curve id="c4" logX="false" logY="false" xDataReference="time"
+        <curve id="c4" xDataReference="time"
         yDataReference="Total_IkBalpha" />
       </listOfCurves>
     </plot2D>

--- a/specification/level-1-version-4/examples/ikappab/ikappab.xml
+++ b/specification/level-1-version-4/examples/ikappab/ikappab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" 
     initialTime="0" outputStartTime="0" outputEndTime="2500"

--- a/specification/level-1-version-4/examples/ikappab/ikappab.xml
+++ b/specification/level-1-version-4/examples/ikappab/ikappab.xml
@@ -3,7 +3,7 @@
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" 
     initialTime="0" outputStartTime="0" outputEndTime="2500"
-    numberOfPoints="1000" >
+    numberOfSteps="1000" >
       <algorithm kisaoID="KISAO:0000019"/>
     </uniformTimeCourse>
   </listOfSimulations>

--- a/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
+++ b/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sedML  xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
-    <uniformTimeCourse id="simulation1" initialTime="0" outputStartTime="0" outputEndTime="380" numberOfPoints="1000">
+    <uniformTimeCourse id="simulation1" initialTime="0" outputStartTime="0" outputEndTime="380" numberOfSteps="1000">
       <algorithm kisaoID="KISAO:0000019" />
     </uniformTimeCourse>
   </listOfSimulations>

--- a/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
+++ b/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML  xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML  xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" initialTime="0" outputStartTime="0" outputEndTime="380" numberOfPoints="1000">
       <algorithm kisaoID="KISAO:0000019" />

--- a/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
+++ b/specification/level-1-version-4/examples/leloup-sbml/leloup-sbml.xml
@@ -63,18 +63,18 @@
   <listOfOutputs>
     <plot2D id="plot1" name="tim mRNA with Oscillation and Chaos">
       <listOfCurves>
-        <curve id="c1" logX="false" logY="false" xDataReference="time" yDataReference="tim1" />
-        <curve id="c2" logX="false" logY="false" xDataReference="time" yDataReference="tim2" />
+        <curve id="c1" xDataReference="time" yDataReference="tim1" />
+        <curve id="c2" xDataReference="time" yDataReference="tim2" />
       </listOfCurves>
     </plot2D>
    <plot2D id="plot2" name="tim mRNA limit cycle (Oscillation)">
       <listOfCurves>
-        <curve id="c3" logX="false" logY="false" xDataReference="per_tim1" yDataReference="tim1" />        
+        <curve id="c3" xDataReference="per_tim1" yDataReference="tim1" />        
       </listOfCurves>
     </plot2D>	
    <plot2D id="plot3" name="tim mRNA limit cycle (chaos)">
       <listOfCurves>
-        <curve id="c4" logX="false" logY="false" xDataReference="per_tim2" yDataReference="tim2" />
+        <curve id="c4" xDataReference="per_tim2" yDataReference="tim2" />
       </listOfCurves>
     </plot2D>	
   </listOfOutputs>

--- a/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
@@ -90,17 +90,17 @@
     <listOfOutputs>
         <plot2D id="plot1">
             <listOfCurves>
-                <curve id="curve1_1" logX="false" logY="false" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
+                <curve id="curve1_1" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
             </listOfCurves>
         </plot2D>
         <plot2D id="plot2">
             <listOfCurves>
-                <curve id="curve2_1" logX="false" logY="false" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
+                <curve id="curve2_1" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
             </listOfCurves>
         </plot2D>
         <plot2D id="plot3">
             <listOfCurves>
-                <curve id="curve3_1" logX="false" logY="false" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
+                <curve id="curve3_1" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
             </listOfCurves>
         </plot2D>
     </listOfOutputs>

--- a/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
     <listOfSimulations>
-        <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="10000" outputEndTime="50" outputStartTime="0">
+        <uniformTimeCourse id="simulation1" initialTime="0" numberOfSteps="10000" outputEndTime="50" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">
                 <listOfAlgorithmParameters>
                     <algorithmParameter kisaoID="KISAO:0000211" value="1e-07"/>

--- a/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-cellml/lorenz.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<sedML level="1" version="2" xmlns="http://sed-ml.org/sed-ml/level1/version2" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+<sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
     <listOfSimulations>
         <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="10000" outputEndTime="50" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">

--- a/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
-    <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="50" numberOfPoints="10000">
+    <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="50" numberOfSteps="10000">
       <algorithm kisaoID="KISAO:0000019">
         <listOfAlgorithmParameters>
             <algorithmParameter kisaoID="KISAO:0000211" value="1e-07"/>

--- a/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
@@ -78,17 +78,17 @@
   <listOfOutputs>
       <plot2D id="plot1">
         <listOfCurves>
-            <curve id="curve1_1" logX="false" logY="false" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
+            <curve id="curve1_1" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
         </listOfCurves>
     </plot2D>
     <plot2D id="plot2">
         <listOfCurves>
-            <curve id="curve2_1" logX="false" logY="false" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
+            <curve id="curve2_1" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
         </listOfCurves>
     </plot2D>
     <plot2D id="plot3">
         <listOfCurves>
-            <curve id="curve3_1" logX="false" logY="false" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
+            <curve id="curve3_1" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
         </listOfCurves>
     </plot2D>
   </listOfOutputs>

--- a/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
+++ b/specification/level-1-version-4/examples/lorenz-sbml/lorenz.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="50" numberOfPoints="10000">
       <algorithm kisaoID="KISAO:0000019">

--- a/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
+++ b/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
@@ -12,7 +12,7 @@
     <task id="task0" modelReference="model1" simulationReference="stepper" />
     <repeatedTask id="task1" resetModel="false" range="index">
       <listOfRanges>
-        <uniformRange id="index" start="0" end="10" numberOfPoints="100" type="linear" />
+        <uniformRange id="index" start="0" end="10" numberOfSteps="100" type="linear" />
         <functionalRange id="current" range="index">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
             <piecewise>

--- a/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
+++ b/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
@@ -97,9 +97,9 @@
   <listOfOutputs>
     <plot2D id="plot1" name="Species Concentration under v0  pulse (Oscli)">
       <listOfCurves>
-        <curve id="curve1" logX="false" logY="false" xDataReference="time_1" yDataReference="S1_1" />
-        <curve id="curve2" logX="false" logY="false" xDataReference="time_1" yDataReference="S2_1" />
-        <curve id="curve3" logX="false" logY="false" xDataReference="time_1" yDataReference="J0_v0_1" />
+        <curve id="curve1" xDataReference="time_1" yDataReference="S1_1" />
+        <curve id="curve2" xDataReference="time_1" yDataReference="S2_1" />
+        <curve id="curve3" xDataReference="time_1" yDataReference="J0_v0_1" />
       </listOfCurves>
     </plot2D>
     <report id="report1" name="Species Concentration under v0  pulse (Oscli)">

--- a/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
+++ b/specification/level-1-version-4/examples/oscli-nested-pulse/oscli-nested-pulse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <oneStep id="stepper" step="0.1">
       <algorithm kisaoID="KISAO:0000019" />

--- a/specification/level-1-version-4/examples/oscli-nested-pulse/oscli.xml
+++ b/specification/level-1-version-4/examples/oscli-nested-pulse/oscli.xml
@@ -11,7 +11,7 @@
             <jd2:header>
                <jd2:VersionHeader JDesignerVersion = "1.0"/>
                <jd2:ModelHeader Author = "" ModelVersion = "" ModelTitle = "Oscli (Heinrich model)"/>
-               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfPoints = "300"/>
+               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfSteps = "300"/>
             </jd2:header>
             <jd2:JDGraphicsHeader BackGroundColor = "FFFFFFEF"/>
             <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/parameter-scan-2d/BorisEJB.xml
+++ b/specification/level-1-version-4/examples/parameter-scan-2d/BorisEJB.xml
@@ -10,7 +10,7 @@
         <jd2:header>
           <jd2:VersionHeader JDesignerVersion="1.0" />
           <jd2:ModelHeader Author="" ModelVersion="" ModelTitle="BorisEJB" />
-          <jd2:TimeCourseDetails timeStart="0" timeEnd="4000" numberOfPoints="1000" />
+          <jd2:TimeCourseDetails timeStart="0" timeEnd="4000" numberOfSteps="1000" />
         </jd2:header>
         <jd2:JDGraphicsHeader BackGroundColor="FFFFFFEF" />
         <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
+++ b/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <steadyState id="steady1">
       <algorithm kisaoID="KISAO:0000282" />

--- a/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
+++ b/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
@@ -38,7 +38,7 @@
     </repeatedTask>
     <repeatedTask id="task2" resetModel="false" range="current1">
       <listOfRanges>
-        <uniformRange id="current1" start="1" end="40" numberOfPoints="100" type="linear" />
+        <uniformRange id="current1" start="1" end="40" numberOfSteps="100" type="linear" />
       </listOfRanges>
       <listOfChanges>
         <setValue target="/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='J4_KK5']"

--- a/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
+++ b/specification/level-1-version-4/examples/parameter-scan-2d/parameter-scan-2d.xml
@@ -113,13 +113,13 @@
   <listOfOutputs>
     <plot2D id="plot1" name="Steady State Scan (Boris 2D)">
       <listOfCurves>
-        <curve id="curve1" logX="false" logY="false" xDataReference="J4_KK5_1" yDataReference="MKK_1" />
-        <curve id="curve2" logX="false" logY="false" xDataReference="J4_KK5_1" yDataReference="MKK_P_1" />
+        <curve id="curve1" xDataReference="J4_KK5_1" yDataReference="MKK_1" />
+        <curve id="curve2" xDataReference="J4_KK5_1" yDataReference="MKK_P_1" />
       </listOfCurves>
     </plot2D>
     <plot2D id="plot2" name="MKK_TOT vs J4_KK5">
       <listOfCurves>
-        <curve id="curve3" logX="false" logY="false" xDataReference="J4_KK5_1" yDataReference="MKK_TOT" />
+        <curve id="curve3" xDataReference="J4_KK5_1" yDataReference="MKK_TOT" />
       </listOfCurves>
     </plot2D>
     <report id="report1" name="Steady State Values (Boris2D)">

--- a/specification/level-1-version-4/examples/plotting-data-csv/oscli.xml
+++ b/specification/level-1-version-4/examples/plotting-data-csv/oscli.xml
@@ -11,7 +11,7 @@
             <jd2:header>
                <jd2:VersionHeader JDesignerVersion = "1.0"/>
                <jd2:ModelHeader Author = "" ModelVersion = "" ModelTitle = "Oscli (Heinrich model)"/>
-               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfPoints = "300"/>
+               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfSteps = "300"/>
             </jd2:header>
             <jd2:JDGraphicsHeader BackGroundColor = "FFFFFFEF"/>
             <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
+++ b/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
@@ -87,9 +87,9 @@
     <listOfOutputs>
         <plot2D id="plot1" name="Time Course (Oscli)">
             <listOfCurves>
-                <curve id="curve1" logX="false" logY="false" xDataReference="time_1" yDataReference="S1_1"/>
-                <curve id="curve2" logX="false" logY="false" xDataReference="time_1" yDataReference="S2_1"/>
-                <curve id="curve3" logX="false" logY="false" xDataReference="dgDataTime" yDataReference="dgDataS1"/>
+                <curve id="curve1" xDataReference="time_1" yDataReference="S1_1"/>
+                <curve id="curve2" xDataReference="time_1" yDataReference="S2_1"/>
+                <curve id="curve3" xDataReference="dgDataTime" yDataReference="dgDataS1"/>
             </listOfCurves>
         </plot2D>
     </listOfOutputs>

--- a/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
+++ b/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML level="1" version="3" xmlns="http://sed-ml.org/sed-ml/level1/version3">
+<sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4">
     <listOfDataDescriptions>
         <dataDescription id="datacsv" name="CSV dataset" source="./oscli.csv" format="urn:sedml:format:csv">
             <dimensionDescription>

--- a/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
+++ b/specification/level-1-version-4/examples/plotting-data-csv/plotting-data-csv.xml
@@ -24,7 +24,7 @@
         </dataDescription>
     </listOfDataDescriptions>
     <listOfSimulations>
-        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfPoints="400">
+        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfSteps="400">
             <algorithm kisaoID="KISAO:0000019">
                 <listOfAlgorithmParameters>
                     <algorithmParameter kisaoID="KISAO:0000209" value="1E-06"/>

--- a/specification/level-1-version-4/examples/plotting-data-numl/oscli.xml
+++ b/specification/level-1-version-4/examples/plotting-data-numl/oscli.xml
@@ -11,7 +11,7 @@
             <jd2:header>
                <jd2:VersionHeader JDesignerVersion = "1.0"/>
                <jd2:ModelHeader Author = "" ModelVersion = "" ModelTitle = "Oscli (Heinrich model)"/>
-               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfPoints = "300"/>
+               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfSteps = "300"/>
             </jd2:header>
             <jd2:JDGraphicsHeader BackGroundColor = "FFFFFFEF"/>
             <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
+++ b/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML level="1" version="3" xmlns="http://sed-ml.org/sed-ml/level1/version3">
+<sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4">
     <listOfDataDescriptions>
         <dataDescription id="Data1" name="oscillator data" source="./oscli.numl" format="urn:sedml:format:numl">
             <dimensionDescription>

--- a/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
+++ b/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
@@ -3,8 +3,7 @@
     <listOfDataDescriptions>
         <dataDescription id="Data1" name="oscillator data" source="./oscli.numl" format="urn:sedml:format:numl">
             <dimensionDescription>
-                <compositeDescription indexType="double" id="time" name="time" xmlns="http://www.numl.org/numl/
-level1/version1">
+                <compositeDescription indexType="double" id="time" name="time" xmlns="http://www.numl.org/numl/level1/version1">
                     <compositeDescription indexType="string" id="SpeciesIds" name="SpeciesIds">
                         <atomicDescription valueType="double" name="Concentrations"/>
                     </compositeDescription>

--- a/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
+++ b/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
@@ -20,7 +20,7 @@
         </dataDescription>
     </listOfDataDescriptions>
     <listOfSimulations>
-        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfPoints="400">
+        <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfSteps="400">
             <algorithm kisaoID="KISAO:0000019">
                 <listOfAlgorithmParameters>
                     <algorithmParameter kisaoID="KISAO:0000209" value="1E-06"/>

--- a/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
+++ b/specification/level-1-version-4/examples/plotting-data-numl/plotting-data-numl.xml
@@ -83,9 +83,9 @@
     <listOfOutputs>
         <plot2D id="plot1" name="Time Course (Oscli)">
             <listOfCurves>
-                <curve id="curve1" logX="false" logY="false" xDataReference="time_1" yDataReference="S1_1"/>
-                <curve id="curve2" logX="false" logY="false" xDataReference="time_1" yDataReference="S2_1"/>
-                <curve id="curve3" logX="false" logY="false" xDataReference="dgDataTime" yDataReference="dgDataS1"/>
+                <curve id="curve1" xDataReference="time_1" yDataReference="S1_1"/>
+                <curve id="curve2" xDataReference="time_1" yDataReference="S2_1"/>
+                <curve id="curve3" xDataReference="dgDataTime" yDataReference="dgDataS1"/>
             </listOfCurves>
         </plot2D>
     </listOfOutputs>

--- a/specification/level-1-version-4/examples/repeated-scan-oscli/oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-scan-oscli/oscli.xml
@@ -11,7 +11,7 @@
             <jd2:header>
                <jd2:VersionHeader JDesignerVersion = "1.0"/>
                <jd2:ModelHeader Author = "" ModelVersion = "" ModelTitle = "Oscli (Heinrich model)"/>
-               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfPoints = "300"/>
+               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfSteps = "300"/>
             </jd2:header>
             <jd2:JDGraphicsHeader BackGroundColor = "FFFFFFEF"/>
             <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
-    <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="20" numberOfPoints="1000">
+    <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="20" numberOfSteps="1000">
       <algorithm kisaoID="KISAO:0000019" />
     </uniformTimeCourse>
   </listOfSimulations>

--- a/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
@@ -68,8 +68,8 @@
   <listOfOutputs>
     <plot2D id="plot1" name="Timecourse  (Oscli) (for v0 = 8, 4, 0.4)">
       <listOfCurves>
-        <curve id="curve1" logX="false" logY="false" xDataReference="time1" yDataReference="S1_1" />
-        <curve id="curve2" logX="false" logY="false" xDataReference="time1" yDataReference="S2_1" />
+        <curve id="curve1" xDataReference="time1" yDataReference="S1_1" />
+        <curve id="curve2" xDataReference="time1" yDataReference="S2_1" />
       </listOfCurves>
     </plot2D>
   </listOfOutputs>

--- a/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-scan-oscli/repeated-scan-oscli.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="20" numberOfPoints="1000">
       <algorithm kisaoID="KISAO:0000019" />

--- a/specification/level-1-version-4/examples/repeated-steady-scan-oscli/oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-steady-scan-oscli/oscli.xml
@@ -11,7 +11,7 @@
             <jd2:header>
                <jd2:VersionHeader JDesignerVersion = "1.0"/>
                <jd2:ModelHeader Author = "" ModelVersion = "" ModelTitle = "Oscli (Heinrich model)"/>
-               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfPoints = "300"/>
+               <jd2:TimeCourseDetails timeStart = "0" timeEnd = "15" numberOfSteps = "300"/>
             </jd2:header>
             <jd2:JDGraphicsHeader BackGroundColor = "FFFFFFEF"/>
             <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
@@ -13,7 +13,7 @@
     <task id="task0" modelReference="model1" simulationReference="steady1" />
     <repeatedTask id="task1" resetModel="true" range="current">
       <listOfRanges>
-        <uniformRange id="current" start="0" end="10" numberOfPoints="100" type="linear" />
+        <uniformRange id="current" start="0" end="10" numberOfSteps="100" type="linear" />
       </listOfRanges>
       <listOfChanges>
         <setValue target="/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='J0_v0']"

--- a/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Written by libSedML v1.1.4992.38982 see http://libsedml.sf.net -->
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <steadyState id="steady1">
       <algorithm kisaoID="KISAO:0000282" />

--- a/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
+++ b/specification/level-1-version-4/examples/repeated-steady-scan-oscli/repeated-steady-scan-oscli.xml
@@ -57,8 +57,8 @@
   <listOfOutputs>
     <plot2D id="plot1" name="Steady State Scan (Oscli)">
       <listOfCurves>
-        <curve id="curve1" logX="false" logY="false" xDataReference="J0_v0_1" yDataReference="S1_1" />
-        <curve id="curve2" logX="false" logY="false" xDataReference="J0_v0_1" yDataReference="S2_1" />
+        <curve id="curve1" xDataReference="J0_v0_1" yDataReference="S1_1" />
+        <curve id="curve2" xDataReference="J0_v0_1" yDataReference="S2_1" />
       </listOfCurves>
     </plot2D>
     <report id="report1" name="Steady State Values">

--- a/specification/level-1-version-4/examples/repeated-stochastic-runs/BorisEJB.xml
+++ b/specification/level-1-version-4/examples/repeated-stochastic-runs/BorisEJB.xml
@@ -10,7 +10,7 @@
         <jd2:header>
           <jd2:VersionHeader JDesignerVersion="1.0" />
           <jd2:ModelHeader Author="" ModelVersion="" ModelTitle="BorisEJB" />
-          <jd2:TimeCourseDetails timeStart="0" timeEnd="4000" numberOfPoints="1000" />
+          <jd2:TimeCourseDetails timeStart="0" timeEnd="4000" numberOfSteps="1000" />
         </jd2:header>
         <jd2:JDGraphicsHeader BackGroundColor="FFFFFFEF" />
         <jd2:listOfCompartments>

--- a/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
+++ b/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
     <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="4000" numberOfPoints="1000">
       <algorithm kisaoID="KISAO:0000241" />

--- a/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
+++ b/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
-    <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="4000" numberOfPoints="1000">
+    <uniformTimeCourse id="timecourse1" initialTime="0" outputStartTime="0" outputEndTime="4000" numberOfSteps="1000">
       <algorithm kisaoID="KISAO:0000241" />
     </uniformTimeCourse>
   </listOfSimulations>
@@ -12,7 +12,7 @@
     <task id="task0" modelReference="model1" simulationReference="timecourse1" />
     <repeatedTask id="task1" resetModel="true" range="current">
       <listOfRanges>
-        <uniformRange id="current" start="0" end="10" numberOfPoints="10" type="linear" />
+        <uniformRange id="current" start="0" end="10" numberOfSteps="10" type="linear" />
       </listOfRanges>
       <listOfSubTasks>
         <subTask order="1" task="task0" />

--- a/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
+++ b/specification/level-1-version-4/examples/repeated-stochastic-runs/repeated-stochastic-runs.xml
@@ -88,13 +88,13 @@
   <listOfOutputs>
     <plot2D id="plot1" name="MAPK feedback (Kholodenko, 2000) (stochastic trace)">
       <listOfCurves>
-        <curve id="curve1" logX="false" logY="false" xDataReference="time1" yDataReference="MAPK1" />
-        <curve id="curve2" logX="false" logY="false" xDataReference="time1" yDataReference="MAPK_P1" />
-        <curve id="curve3" logX="false" logY="false" xDataReference="time1" yDataReference="MAPK_PP1" />
-        <curve id="curve4" logX="false" logY="false" xDataReference="time1" yDataReference="MKK1" />
-        <curve id="curve5" logX="false" logY="false" xDataReference="time1" yDataReference="MKKK1" />
-        <curve id="curve6" logX="false" logY="false" xDataReference="time1" yDataReference="MKK_P1" />
-        <curve id="curve7" logX="false" logY="false" xDataReference="time1" yDataReference="MKKK_P1" />
+        <curve id="curve1" xDataReference="time1" yDataReference="MAPK1" />
+        <curve id="curve2" xDataReference="time1" yDataReference="MAPK_P1" />
+        <curve id="curve3" xDataReference="time1" yDataReference="MAPK_PP1" />
+        <curve id="curve4" xDataReference="time1" yDataReference="MKK1" />
+        <curve id="curve5" xDataReference="time1" yDataReference="MKKK1" />
+        <curve id="curve6" xDataReference="time1" yDataReference="MKK_P1" />
+        <curve id="curve7" xDataReference="time1" yDataReference="MKKK_P1" />
       </listOfCurves>
     </plot2D>
   </listOfOutputs>

--- a/specification/level-1-version-4/examples/repressilator/repressilator.xml
+++ b/specification/level-1-version-4/examples/repressilator/repressilator.xml
@@ -2,7 +2,7 @@
 <!-- Created by phraSED-ML version v1.0.7 with libSBML version 5.15.0. -->
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>
-    <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="1000" numberOfPoints="1000">
+    <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="1000" numberOfSteps="1000">
       <algorithm kisaoID="KISAO:0000019"/>
     </uniformTimeCourse>
   </listOfSimulations>

--- a/specification/level-1-version-4/examples/repressilator/repressilator.xml
+++ b/specification/level-1-version-4/examples/repressilator/repressilator.xml
@@ -130,23 +130,23 @@
   <listOfOutputs>
     <plot2D id="timecourse" name="Timecourse of repressilator">
       <listOfCurves>
-        <curve id="plot_0__plot_0_0_0__plot_0_0_1" logX="false" logY="false" xDataReference="dg_0_0_0" yDataReference="dg_0_0_1"/>
-        <curve id="plot_0__plot_0_0_0__plot_0_1_1" logX="false" logY="false" xDataReference="dg_0_0_0" yDataReference="dg_0_1_1"/>
-        <curve id="plot_0__plot_0_0_0__plot_0_2_1" logX="false" logY="false" xDataReference="dg_0_0_0" yDataReference="dg_0_2_1"/>
+        <curve id="plot_0__plot_0_0_0__plot_0_0_1" xDataReference="dg_0_0_0" yDataReference="dg_0_0_1"/>
+        <curve id="plot_0__plot_0_0_0__plot_0_1_1" xDataReference="dg_0_0_0" yDataReference="dg_0_1_1"/>
+        <curve id="plot_0__plot_0_0_0__plot_0_2_1" xDataReference="dg_0_0_0" yDataReference="dg_0_2_1"/>
       </listOfCurves>
     </plot2D>
     <plot2D id="preprocessing" name="Timecourse after pre-processing">
       <listOfCurves>
-        <curve id="plot_1__plot_1_0_0__plot_1_0_1" logX="false" logY="false" xDataReference="dg_1_0_0" yDataReference="dg_1_0_1"/>
-        <curve id="plot_1__plot_1_0_0__plot_1_1_1" logX="false" logY="false" xDataReference="dg_1_0_0" yDataReference="dg_1_1_1"/>
-        <curve id="plot_1__plot_1_0_0__plot_1_2_1" logX="false" logY="false" xDataReference="dg_1_0_0" yDataReference="dg_1_2_1"/>
+        <curve id="plot_1__plot_1_0_0__plot_1_0_1" xDataReference="dg_1_0_0" yDataReference="dg_1_0_1"/>
+        <curve id="plot_1__plot_1_0_0__plot_1_1_1" xDataReference="dg_1_0_0" yDataReference="dg_1_1_1"/>
+        <curve id="plot_1__plot_1_0_0__plot_1_2_1" xDataReference="dg_1_0_0" yDataReference="dg_1_2_1"/>
       </listOfCurves>
     </plot2D>
     <plot2D id="postprocessing" name="Timecourse after post-processing">
       <listOfCurves>
-        <curve id="plot_2__plot_2_0_0__plot_2_0_1" logX="false" logY="false" xDataReference="dg_2_0_0" yDataReference="dg_2_0_1"/>
-        <curve id="plot_2__plot_2_1_0__plot_2_0_0" logX="false" logY="false" xDataReference="dg_2_1_0" yDataReference="dg_2_0_0"/>
-        <curve id="plot_2__plot_2_0_1__plot_2_1_0" logX="false" logY="false" xDataReference="dg_2_0_1" yDataReference="dg_2_1_0"/>
+        <curve id="plot_2__plot_2_0_0__plot_2_0_1" xDataReference="dg_2_0_0" yDataReference="dg_2_0_1"/>
+        <curve id="plot_2__plot_2_1_0__plot_2_0_0" xDataReference="dg_2_1_0" yDataReference="dg_2_0_0"/>
+        <curve id="plot_2__plot_2_0_1__plot_2_1_0" xDataReference="dg_2_0_1" yDataReference="dg_2_1_0"/>
       </listOfCurves>
     </plot2D>
   </listOfOutputs>

--- a/specification/level-1-version-4/examples/repressilator/repressilator.xml
+++ b/specification/level-1-version-4/examples/repressilator/repressilator.xml
@@ -1,4 +1,4 @@
-?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by phraSED-ML version v1.0.7 with libSBML version 5.15.0. -->
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfSimulations>

--- a/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
@@ -88,13 +88,13 @@
     <listOfOutputs>
         <plot2D id="plot1">
             <listOfCurves>
-                <curve id="curve1_1" logX="false" logY="false" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
-                <curve id="curve2_1" logX="false" logY="false" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
+                <curve id="curve1_1" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
+                <curve id="curve2_1" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
             </listOfCurves>
         </plot2D>
         <plot2D id="plot2">
             <listOfCurves>
-                <curve id="curve3_1" logX="false" logY="false" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
+                <curve id="curve3_1" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
             </listOfCurves>
         </plot2D>
     </listOfOutputs>

--- a/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<sedML level="1" version="3" xmlns="http://sed-ml.org/sed-ml/level1/version3" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+<sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
     <listOfSimulations>
         <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="1000" outputEndTime="100" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">

--- a/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-cellml/vanderpol.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
     <listOfSimulations>
-        <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="1000" outputEndTime="100" outputStartTime="0">
+        <uniformTimeCourse id="simulation1" initialTime="0" numberOfSteps="1000" outputEndTime="100" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">
                 <listOfAlgorithmParameters>
                     <algorithmParameter kisaoID="KISAO:0000211" value="1e-07"/>

--- a/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
@@ -88,13 +88,13 @@
     <listOfOutputs>
         <plot2D id="plot1">
             <listOfCurves>
-                <curve id="curve1_1" logX="false" logY="false" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
-                <curve id="curve2_1" logX="false" logY="false" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
+                <curve id="curve1_1" xDataReference="xDataGenerator1_1" yDataReference="yDataGenerator1_1"/>
+                <curve id="curve2_1" xDataReference="xDataGenerator2_1" yDataReference="yDataGenerator2_1"/>
             </listOfCurves>
         </plot2D>
         <plot2D id="plot2">
             <listOfCurves>
-                <curve id="curve3_1" logX="false" logY="false" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
+                <curve id="curve3_1" xDataReference="xDataGenerator3_1" yDataReference="yDataGenerator3_1"/>
             </listOfCurves>
         </plot2D>
     </listOfOutputs>

--- a/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4">
     <listOfSimulations>
-        <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="1000" outputEndTime="100" outputStartTime="0">
+        <uniformTimeCourse id="simulation1" initialTime="0" numberOfSteps="1000" outputEndTime="100" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">
                 <listOfAlgorithmParameters>
                     <algorithmParameter kisaoID="KISAO:0000211" value="1e-07"/>

--- a/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
+++ b/specification/level-1-version-4/examples/vanderpol-sbml/vanderpol.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<sedML level="1" version="3" xmlns="http://sed-ml.org/sed-ml/level1/version3">
+<sedML level="1" version="4" xmlns="http://sed-ml.org/sed-ml/level1/version4">
     <listOfSimulations>
         <uniformTimeCourse id="simulation1" initialTime="0" numberOfPoints="1000" outputEndTime="100" outputStartTime="0">
             <algorithm kisaoID="KISAO:0000019">

--- a/specification/releases/level-1-version-1-release-1/xml/leloupCellml.xml
+++ b/specification/releases/level-1-version-1-release-1/xml/leloupCellml.xml
@@ -4,7 +4,7 @@
  <notes><p xmlns="http://www.w3.org/1999/xhtml">Comparing Limit Cycles and strange attractors for
         oscillation in Drosophila</p></notes> 
  <listOfSimulations>
-   <uniformTimeCourse id="simulation1" algorithm="KiSAO:0000019" 
+   <uniformTimeCourse id="simulation1"
     initialTime="0" outputStartTime="0" outputEndTime="380" 
     numberOfPoints="1000" >
      <algorithm kisaoID="KISAO:0000019"/>

--- a/specification/releases/level-1-version-1-release-1/xml/leloupSbml.xml
+++ b/specification/releases/level-1-version-1-release-1/xml/leloupSbml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Written by libSedML v1.1.4092.21172 see http://libsedml.sf.net -->
-<sedML xmlns="http://www.biomodels.net/sed-ml">
+<sedML xmlns="http://sed-ml.org/" level="1" version="1">
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" initialTime="0" outputStartTime="0" outputEndTime="380" numberOfPoints="1000">
       <algorithm kisaoID="KISAO:0000019" />

--- a/specification/releases/level-1-version-2-release-1/xml/IkBNFkB_Signaling.xml
+++ b/specification/releases/level-1-version-2-release-1/xml/IkBNFkB_Signaling.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sedML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://sed-ml.org/ sed-ml-L1-V1.xsd" xmlns="http://sed-ml.org/sed-ml/level1/version2" level="1"
- version="1">
+ version="2">
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" 
     initialTime="0" outputStartTime="0" outputEndTime="2500"

--- a/specification/releases/level-1-version-2-release-1/xml/leloupCellml.xml
+++ b/specification/releases/level-1-version-2-release-1/xml/leloupCellml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sedML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://sed-ml.org/ sed-ml-L1-V1.xsd"
- xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns="http://sed-ml.org/sed-ml/level1/version2" level="1" version="1">
+ xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns="http://sed-ml.org/sed-ml/level1/version2" level="1" version="2">
  <notes><p xmlns="http://www.w3.org/1999/xhtml">Comparing Limit Cycles and strange attractors for
         oscillation in Drosophila</p></notes> 
  <listOfSimulations>

--- a/specification/releases/level-1-version-2-release-1/xml/leloupSbml.xml
+++ b/specification/releases/level-1-version-2-release-1/xml/leloupSbml.xml
@@ -2,7 +2,7 @@
 <!-- Written by libSedML v1.1.4092.21172 see http://libsedml.sf.net -->
 <sedML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://sed-ml.org/ sed-ml-L1-V1.xsd" xmlns="http://sed-ml.org/sed-ml/level1/version2" level="1"
- version="1">
+ version="2">
   <listOfSimulations>
     <uniformTimeCourse id="simulation1" initialTime="0" outputStartTime="0" outputEndTime="380" numberOfPoints="1000">
       <algorithm kisaoID="KISAO:0000019" />


### PR DESCRIPTION
I've been using the examples to test a `pydantic` implementation of a SED-ML reader, and found some issues.

I'm not entirely sure about the changes to:

1. `specification/releases/level-1-version-1-release-1/xml/leloupSbml.xml`
```diff
-<sedML xmlns="http://www.biomodels.net/sed-ml">
+<sedML xmlns="http://sed-ml.org/" level="1" version="1">
```

2. `specification/releases/level-1-version-1-release-1/xml/leloupCellml.xml`
```diff
-   <uniformTimeCourse id="simulation1" algorithm="KiSAO:0000019" 
+   <uniformTimeCourse id="simulation1"
```

but the rest of the changes should be ok.